### PR TITLE
Update to work with latest elixir project structures

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Plugin 'renderedtext/vim-elixir-alternative-files'
 Currently, you have to define a shortcut:
 
 ```
-nnoremap <silent><leader>t :call ElixirAlternateFile()<cr>
+nnoremap <silent><leader><leader> :call ElixirAlternateFile()<cr>
 ```
 
 My plan for the future is to make use of `:A`, but currently it is clashing with

--- a/plugin/elixir-alternate.vim
+++ b/plugin/elixir-alternate.vim
@@ -1,14 +1,8 @@
 function! ElixirGetAlternateFilenameForImplementation(filepath)
   let currentFileRoot = split(a:filepath, ".ex$")[0]
 
-  if empty(matchstr(currentFileRoot, "web"))
-    " in lib directory
-    let fileToOpen = "test/" . currentFileRoot . "_test.exs"
-  else
-    " in web directory
-    let pathWithoutWeb = split(currentFileRoot, "^web/")[0]
-    let fileToOpen = "test/" . pathWithoutWeb. "_test.exs"
-  endif
+  let pathWithoutLib = split(currentFileRoot, "^lib/")[0]
+  let fileToOpen = "test/" . pathWithoutLib . "_test.exs"
 
   return fileToOpen
 endfunction
@@ -17,12 +11,8 @@ function! ElixirGetAlternateFilenameForTest(filepath)
   let currentFileRoot = split(a:filepath, "_test.exs$")[0]
   let pathWithoutTest = split(currentFileRoot, "^test/")[0]
 
-  if empty(matchstr(pathWithoutTest, "^lib"))
-    let fileToOpen = "web/" . pathWithoutTest . ".ex"
-  else
-    let fileToOpen = pathWithoutTest . ".ex"
-  endif
-
+  let fileToOpen = "lib/" . pathWithoutTest . ".ex"
+  
   return fileToOpen
 endfunction
 


### PR DESCRIPTION
Previosly a file in `lib/example/path.ex` would look for the tests in `test/lib/example/path_test.exs`, and `web/controllers/example.ex` in `test/controllers/example_test.exs`.

This approach is now deprecated. The current approach for the latest Phoenix/Elixir releases is:

``` bash
lib/example/something.ex -> test/example/something.ex
lib/example_web/something.ex -> test/example_web/something.ex
```