### PR TITLE
Make it work for umbrella project

### DIFF
--- a/plugin/elixir-alternate.vim
+++ b/plugin/elixir-alternate.vim
@@ -1,18 +1,18 @@
 function! ElixirGetAlternateFilenameForImplementation(filepath)
   let currentFileRoot = split(a:filepath, ".ex$")[0]
 
-  let pathWithoutLib = split(currentFileRoot, "^lib/")[0]
-  let fileToOpen = "test/" . pathWithoutLib . "_test.exs"
+  let testPath = substitute(currentFileRoot, "lib/", "test/", "")
+  let fileToOpen = testPath . "_test.exs"
 
   return fileToOpen
 endfunction
 
 function! ElixirGetAlternateFilenameForTest(filepath)
   let currentFileRoot = split(a:filepath, "_test.exs$")[0]
-  let pathWithoutTest = split(currentFileRoot, "^test/")[0]
 
-  let fileToOpen = "lib/" . pathWithoutTest . ".ex"
-  
+  let implementationPath = substitute(currentFileRoot, "test/", "lib/", "")
+  let fileToOpen = implementationPath . ".ex"
+
   return fileToOpen
 endfunction
 


### PR DESCRIPTION
Use substitution instead of splitting since splitting assumes buffer path starts with `lib/` or `test/` which is not always true with umbrella project where your path is usually `apps/some_app/lib/` or `apps/some_app/test`.